### PR TITLE
Split Readme into smaller files to improve readability

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,4 +1,4 @@
-## Frequently Asked Questions - FAQ ##
+# Frequently Asked Questions - FAQ #
 
 ### My event is not listed/wrongly classified/there is a mistake! ###
 No problem - please see [**How do I Contribute**](https://github.com/Readify/DevEvents/blob/master/contributing.md) for details of how you can fix this, or add an issue and we'll look into it.
@@ -9,18 +9,19 @@ If an event is not listed, it might be that the event isn't sufficiently targete
 
 We're looking for events that match the following basic criteria:
 
-- It's an Australian based event, anytime from 2016 onwards
-- It needs to be of interest to the software development community
+- _It's an Australian based event, run anytime from 2016 onwards_
+- _It's of interest to the software development community_
 
-We don't care if it's free or not, and we don't care if it's an in-person event or a virtual one. As long as it meets the first two criteria, we're happy!
+It doesn't matter if it's free or not, and we don't care if it's an in-person event or a virtual one. As long as it meets the criteria, we're happy!
 
 As a note; User groups, meetups, and other regular, recurring events won't get listed. [Meetup](https://meetup.com) is already well established as the best place for publicising those type of events. We don't need to reinvent the wheel.
 
-
 ### This should be done using RSS/ATOM/Microformat/JSON/Blockchain etc ###
+
 This resource is only as good as people's contributions so we want to make it as easy as possible for people to make changes. Markdown in conjunction with GitHub markdown editor makes it very easy for anyone to modify the content, even without tooling. Feel free to build something cool based on this data.
 
 ### I am not technical - how can I contribute to this? ###
+
 Please [sign up on github](https://github.com/join) and follow the easy steps in the [**Contribution Guide**](https://github.com/Readify/DevEvents/blob/master/contributing.md). You can also add an issue by clicking on the issue tab and we will get to it when we can.
 
 ### What is Readify's involvement ###

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,30 @@
+## Frequently Asked Questions - FAQ ##
+
+### My event is not listed/wrongly classified/there is a mistake! ###
+No problem - please see [**How do I Contribute**](https://github.com/Readify/DevEvents/blob/master/contributing.md) for details of how you can fix this, or add an issue and we'll look into it.
+
+If an event is not listed, it might be that the event isn't sufficiently targeted at developers. If you disagree, open an issue and state your case. We're happy to find out more.
+
+### What type of events will get listed? ###
+
+We're looking for events that match the following basic criteria:
+
+- It's an Australian based event, anytime from 2016 onwards
+- It needs to be of interest to the software development community
+
+We don't care if it's free or not, and we don't care if it's an in-person event or a virtual one. As long as it meets the first two criteria, we're happy!
+
+As a note; User groups, meetups, and other regular, recurring events won't get listed. [Meetup](https://meetup.com) is already well established as the best place for publicising those type of events. We don't need to reinvent the wheel.
+
+
+### This should be done using RSS/ATOM/Microformat/JSON/Blockchain etc ###
+This resource is only as good as people's contributions so we want to make it as easy as possible for people to make changes. Markdown in conjunction with GitHub markdown editor makes it very easy for anyone to modify the content, even without tooling. Feel free to build something cool based on this data.
+
+### I am not technical - how can I contribute to this? ###
+Please [sign up on github](https://github.com/join) and follow the easy steps in the [**Contribution Guide**](https://github.com/Readify/DevEvents/blob/master/contributing.md). You can also add an issue by clicking on the issue tab and we will get to it when we can.
+
+### What is Readify's involvement ###
+[Readify](https://readify.net) is an Australian IT Consultancy and this repository is hosted under the Readify organization. Readify team members merge PR requests. All events related to developers are welcome including those of our competitors.
+
+### What is the license for this project? ###
+This repository is licensed under Creative Commons CC0.

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,30 @@
+# Contributing #
+
+You want to help? Great!! Here's what you need to know.
+
+### How do I contribute? ###
+
+Contributing to DevEvents is very easy with the GitHub markdown editor; you can do it all from your browser. (You are also welcome to use a standard PR process if you would prefer.)
+
+To submit a change using GitHub markdown editor, do the following:
+
+1. Browse to [readme.md](https://github.com/Readify/DevEvents/blob/master/readme.md), the actual file behind it all
+1. Click the [_Edit this file_ pencil icon](https://github.com/Readify/DevEvents/edit/master/readme.md)
+1. Make your changes, respecting the rules below please
+1. Use the _Preview Changes_ tab at the top to make sure everything still looks right
+1. Scroll to the _Commit Changes_ section at the bottom
+1. Supply a basic description of your change in the first field (`Add Super Awesome Conf 2019`)
+1. Select the _Create a new branch for this commit and start a pull request_ option
+1. Hit _Propose file change_
+1. Hit _Create pull request_
+
+For content:
+
+- Note we are currently only interested in Australian based events and no earlier than 2016
+- The event should be of interest to the dev community (specialist and related topics are fine e.g. AI and agile)
+- Please add events in reverse chronological order
+- Check any links you are adding are correct
+- Ensure dates are in dd/mm/yyyy format (in case we want to parse this data later)
+- Ensure no additional spaces or formatting characters are present (this will make parsing easier later)
+- Ensure states are specified as VIC, NSW, ACT, WA, SA, NT, QLD, ALL, TAS, OTH (Other)
+

--- a/contributing.md
+++ b/contributing.md
@@ -22,7 +22,7 @@ For content:
 
 - Note we are currently only interested in Australian based events and no earlier than 2016
 - The event should be of interest to the dev community (specialist and related topics are fine e.g. AI and agile)
-- Please add events in reverse chronological order
+- Please add events in chronological order within the relevant year
 - Check any links you are adding are correct
 - Ensure dates are in dd/mm/yyyy format (in case we want to parse this data later)
 - Ensure no additional spaces or formatting characters are present (this will make parsing easier later)

--- a/contributing.md
+++ b/contributing.md
@@ -20,11 +20,11 @@ To submit a change using GitHub markdown editor, do the following:
 
 For content:
 
-- Note we are currently only interested in Australian based events and no earlier than 2016
+- We are only interested in Australian based events, and no earlier than 2016
 - The event should be of interest to the dev community (specialist and related topics are fine e.g. AI and agile)
 - Please add events in chronological order within the relevant year
 - Check any links you are adding are correct
-- Ensure dates are in dd/mm/yyyy format (in case we want to parse this data later)
+- Ensure dates are in dd/mm/yyyy format (in case we want to parse this data later). Use TBC if the date is unconfirmed or unknown.
 - Ensure no additional spaces or formatting characters are present (this will make parsing easier later)
 - Ensure states are specified as VIC, NSW, ACT, WA, SA, NT, QLD, ALL, TAS, OTH (Other)
 

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ If you want to make an addition or fix up a mistake please consider [contributin
 
 ## FAQ ##
 
-You've got a question, do you? Awesome! [The FAQ](https://github.com/Readify/DevEvents/blob/master/faq.md) likely has the answer you need.
+You've got a question, do you? Awesome! [The FAQ](https://github.com/Readify/DevEvents/blob/master/FAQ.md) likely has the answer you need.
 
 ### Can I contribute? ###
 

--- a/readme.md
+++ b/readme.md
@@ -1,51 +1,18 @@
 # Australian Dev Events
 
-This repository contains events occurring in Australia of interest to developers covering everything from technical focused topics to leadership to agile.
+This repository contains events occurring in Australia of interest to software developers covering everything from technical focused topics to leadership to agility.
 
-If you want to make an addition or fix up a mistake please consider contributing to keep this a useful resource.
+If you want to make an addition or fix up a mistake please consider [contributing](https://github.com/Readify/DevEvents/blob/master/contributing.md) to keep this list current and useful.
 
 ## FAQ ##
 
-### My event is not listed/wrongly classified/there is a mistake! ###
-No problem - please see [**How do I Contribute**](https://github.com/Readify/DevEvents#how-do-i-contribute) for details of how you can fix this
+You've got a question, do you? Awesome! [The FAQ](https://github.com/Readify/DevEvents/blob/master/faq.md) likely has the answer you need.
 
-### This should be done using RSS/ATOM/Microformat/JSON/Blockchain etc ###
-This resource is only as good as people's contributions so we wanted to make it as easy as possible for people to make changes. Markdown in conjunction with GitHub markdown editor makes it very easy for anyone to modify the content. Feel free to build something cool based on this data.
+### Can I contribute? ###
 
-### I am not technical - how can I contribute to this? ###
-Please [sign up on github](https://github.com/join) and follow the easy steps detailed at [**How do I Contribute**](https://github.com/Readify/DevEvents#how-do-i-contribute). You can also log an issue by clicking the issue tab and we will get to it when we can.
+Of course! We'd love it if you would! See the [contribution guide](https://github.com/Readify/DevEvents/blob/master/contributing.md) for how.
 
-### What is Readify's involvement ###
-[Readify](https://readify.net) is an Australian IT Consultancy and this repository is hosted under the Readify organization. Readify team members merge PR requests. All events related to developers are welcome including those of our competitors.
-
-### What is the license for this project? ###
-This repository is licensed under Creative Commons CC0.
-
-### How do I contribute? ###
-
-Contributing to DevEvents is very easy with the GitHub markdown editor; you can do it all from your browser. (You are also welcome to use a standard PR process if you would prefer.)
-
-To submit a change using GitHub markdown editor, do the following:
-
-1. Browse to [readme.md](https://github.com/Readify/DevEvents/blob/master/readme.md), the actual file behind it all
-1. Click the [_Edit this file_ pencil icon](https://github.com/Readify/DevEvents/edit/master/readme.md)
-1. Make your changes, respecting the rules below please
-1. Use the _Preview Changes_ tab at the top to make sure everything still looks right
-1. Scroll to the _Commit Changes_ section at the bottom
-1. Supply a basic description of your change in the first field (`Add Super Awesome Conf 2019`)
-1. Select the _Create a new branch for this commit and start a pull request_ option
-1. Hit _Propose file change_
-1. Hit _Create pull request_
-
-For content:
-
-- Note we are currently only interested in Australian based events and no earlier than 2016
-- The event should be of interest to the dev community (specialist and related topics are fine e.g. AI and agile)
-- Please add events in chronological order
-- Check any links you are adding are correct
-- Ensure dates are in dd/mm/yyyy format (in case we want to parse this data later)
-- Ensure no additional spaces or formatting characters are present (this will make parsing easier later)
-- Ensure states are specified as VIC, NSW, ACT, WA, SA, NT, QLD, ALL, TAS, OTH (Other)
+# The Events List #
 
 ## 2018 ##
 


### PR DESCRIPTION
Move the contributing and FAQ sections into their own files.
Make the Readme file more about the actual information so that the list isn't "below the fold".

Made a number of small content and wording changes as well.