### PR TITLE
update contributing guide date format

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -23,7 +23,7 @@ For content:
 - The event should be of interest to the dev community (specialist and related topics are fine e.g. AI and agile)
 - Please add events in chronological order within the relevant year
 - Check any links you are adding are correct
-- Ensure dates are in dd/mm/yyyy format (in case we want to parse this data later). Use TBC if the date is unconfirmed or unknown.
+- Ensure dates are in dd-mmm-yyyy format (in case we want to parse this data later). For example, `01-Jan-2019`. Use TBC if the date is unconfirmed or unknown.
 - Ensure no additional spaces or formatting characters are present (this will make parsing easier later)
 - Ensure states are specified as VIC, NSW, ACT, WA, SA, NT, QLD, ALL, TAS, OTH (Other)
 


### PR DESCRIPTION
The format requested was used for 2016 and 2017 data, but from then on the
format changed. Probably easier to re-standardise on recent data than to
coerce recent data to fit.

ref https://github.com/Readify/DevEvents/issues/69